### PR TITLE
[Update] Update dependencies and revise download links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   build_test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,9 +17,6 @@ jobs:
           python-version: 3.8
       - name: Install pre-commit hook
         run: |
-          sudo apt-add-repository ppa:brightbox/ruby-ng -y
-          sudo apt-get update
-          sudo apt-get install -y ruby2.7
           pip install pre-commit
           pre-commit install
       - name: Linting

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.8.3
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
   - repo: https://github.com/asottile/seed-isort-config.git
@@ -9,7 +9,7 @@ repos:
       - id: seed-isort-config
         args: [--settings-path, ./]
   - repo: https://github.com/PyCQA/isort.git
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: [--settings-file, ./setup.cfg]

--- a/docs/en/dataset_preparation.md
+++ b/docs/en/dataset_preparation.md
@@ -13,7 +13,7 @@ In this document we describe the data involved in XRMoGen and how to use it.
 
 ## Download Data
 
-The dataset used in the dance generation task is AIST++. It contains [original music](https://aistdancedb.ongaaccel.jp/database_download/) and motion annotations(https://google.github.io/aistplusplus_dataset/download.html). In XRMoGen, we provide extracted musical features (438 dimensions) and 3D coordinates of human key points extracted based on the SMPL model (download [here](https://openxrlab-share-mainland.oss-cn-hangzhou.aliyuncs.com/xrmogen/data.zip)).
+The dataset used in the dance generation task is AIST++. It contains [original music](https://aistdancedb.ongaaccel.jp/database_download/) and motion annotations(https://google.github.io/aistplusplus_dataset/download.html). In XRMoGen, we provide extracted musical features (438 dimensions) and 3D coordinates of human key points extracted based on the SMPL model (download [here](https://drive.google.com/file/d/133I4HB4JUF_Q9RbyWiveaq4KY6ykODjf/view?usp=sharing)).
 
 
 ## Data Structure

--- a/docs/en/pretrained_model_list.md
+++ b/docs/en/pretrained_model_list.md
@@ -2,5 +2,5 @@
 
 | model | weight link |
 | :----------------: | :------------------------: |
-| Bailando | [bailando.pth](https://openxrlab-share-mainland.oss-cn-hangzhou.aliyuncs.com/xrmogen/weights/bailando.pth) |
-| DanceRevolution | [dance_revolution.pth](https://openxrlab-share-mainland.oss-cn-hangzhou.aliyuncs.com/xrmogen/weights/dance_revolution.pth) |
+| Bailando | [bailando.pth](https://drive.google.com/file/d/1ZYdBoS_KWZ2Ck1XzLK0rfs1RehnI6I45/view?usp=sharing) |
+| DanceRevolution | [dance_revolution.pth](https://drive.google.com/file/d/1CTdW54Ann_zz4qAqGyQNipv7iWiPgUFD/view?usp=sharing) |

--- a/docs/zh_cn/dataset_preparation.md
+++ b/docs/zh_cn/dataset_preparation.md
@@ -13,7 +13,7 @@
 
 ## 获取数据
 
-mogen舞蹈生成任务中采用的数据集是AIST++。包含[原始音乐](https://aistdancedb.ongaaccel.jp/database_download/)，和[动作标注](https://google.github.io/aistplusplus_dataset/download.html)。在xrmogen中，我们提供抽取的音乐特征(438维）以及基于smpl模型提取的人体关键点三维坐标（[此处](https://openxrlab-share-mainland.oss-cn-hangzhou.aliyuncs.com/xrmogen/data.zip)下载）。
+mogen舞蹈生成任务中采用的数据集是AIST++。包含[原始音乐](https://aistdancedb.ongaaccel.jp/database_download/)，和[动作标注](https://google.github.io/aistplusplus_dataset/download.html)。在xrmogen中，我们提供抽取的音乐特征（438维）以及基于smpl模型提取的人体关键点三维坐标（[此处](https://drive.google.com/file/d/133I4HB4JUF_Q9RbyWiveaq4KY6ykODjf/view?usp=sharing)下载）。
 
 
 ## 数据结构

--- a/docs/zh_cn/pretrained_model_list.md
+++ b/docs/zh_cn/pretrained_model_list.md
@@ -2,5 +2,5 @@
 
 | 模型 | 预训练权重链接 |
 | :----------------: | :------------------------: |
-| Bailando | [bailando.pth](https://openxrlab-share-mainland.oss-cn-hangzhou.aliyuncs.com/xrmogen/weights/bailando.pth) |
-| DanceRevolution | [dance_revolution.pth](https://openxrlab-share-mainland.oss-cn-hangzhou.aliyuncs.com/xrmogen/weights/dance_revolution.pth) |
+| Bailando | [bailando.pth](https://drive.google.com/file/d/1ZYdBoS_KWZ2Ck1XzLK0rfs1RehnI6I45/view?usp=sharing) |
+| DanceRevolution | [dance_revolution.pth](https://drive.google.com/file/d/1CTdW54Ann_zz4qAqGyQNipv7iWiPgUFD/view?usp=sharing) |


### PR DESCRIPTION
- Updated Flake8 from version 3.8.3 to 5.0.4 and isort from 5.10.1 to 5.12.0 in the pre-commit configuration.
- Revised download links for dataset and pretrained models in both English and Chinese documentation.